### PR TITLE
Create GitHub action to look for deadlinks

### DIFF
--- a/.github/workflows/deadllnk.yml
+++ b/.github/workflows/deadllnk.yml
@@ -1,0 +1,23 @@
+name: Check markdown links
+on: 
+  schedule:
+    - cron: '1 6 * * 5'
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Link Checker
+        uses: peter-evans/link-checker@v1
+        with: # TODO we could use something like ls *.md */**/*.md > some_variable to achieve this dynamically 
+          args: --timeout 60 --exclude https://www.agilealliance.org/glossary/tdd/ --document-root README.md CONTRIBUTING.md CODE_OF_CONDUCT.md docs/03-team.md docs/04-development.md docs/08-troubleshooting.md docs/index.md docs/setuphelp.md
+
+      - name: Create Issue From File
+        uses: peter-evans/create-issue-from-file@v2
+        with:
+          title: Link Checker Report
+          content-filepath: ./link-checker/out.md
+          labels: bug, automated issue

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ The meetings collected by this project is posted to this [calendar](https://pgh-
 
 ## Join our community
 
-- [Fill out this form](https://airtable.com/shrsdRcYVzp019U22) to join our [Slack channel](https://citybureau.slack.com/#labs_city_scrapers)
+- [Fill out this form](https://airtable.com/shrRv027NLgToRFd6) to join our [Slack channel](https://citybureau.slack.com/#labs_city_scrapers)

--- a/docs/04-development.md
+++ b/docs/04-development.md
@@ -110,7 +110,7 @@ Congratulations - this means that Scrapy is working and we are ready to contribu
 If you're having any issues at this point, here are some options:
 - Talk to other contributors on [Slack](https://citybureau.slack.com/) or at our [Meetups](https://www.meetup.com/codeforpgh/). It's very likely that someone else has encountered your situation before and can *quickly* point you in the right direction.
 - See if your problem shows up in our [issues](https://github.com/pgh-public-meetings/city-scrapers-pitt/issues) page.
-- [Googling the error message](http://www.meh.ro/wp-content/uploads/2017/01/meh.ro12456.jpg)
+- [Googling the error message](https://miro.medium.com/max/700/1*7P1FchNLHq7fHjCOrY0wPw.png)
 - [StackOverflow](https://stackoverflow.com/)
 
 ## Contribute


### PR DESCRIPTION
After maintaining the docs for a while and using things like [dead link checker ](https://www.deadlinkchecker.com/website-dead-link-checker.asp), it occurred to me that it would be more efficient to automate this. 