### PR TITLE
Fixing issues with PittHousingSpider meetings (prod failures)

### DIFF
--- a/city_scrapers/spiders/pitt_housing.py
+++ b/city_scrapers/spiders/pitt_housing.py
@@ -36,10 +36,12 @@ class PittHousingSpider(CityScrapersSpider):
                     end=None,
                     all_day=False,
                     time_notes="",
-                    location={"address": location_str.strip()},
+                    location={"address": location_str.strip(), "name": ""},
                     links=[],
                     source=response.url,
                 )
+                meeting["status"] = self._get_status(meeting)
+                meeting["id"] = self._get_id(meeting)
                 yield meeting
 
     def _parse_title(self, _):

--- a/tests/test_pitt_housing.py
+++ b/tests/test_pitt_housing.py
@@ -74,6 +74,7 @@ def test_location():
     idx = 0
     for item in parsed_items:
         assert item["location"]["address"] == expected_locations[idx]
+        assert item["location"]["name"] == ""
         idx += 1
 
 
@@ -87,9 +88,6 @@ def test_all_day():
         assert item["all_day"] is False
 
 
-# The 'id' or 'source' fields aren't customized currently, so these are commented out.
-# def test_id():
-#     assert parsed_items[0]["id"] == "EXPECTED ID"
-
-# def test_source():
-#     assert parsed_items[0]["source"] == "EXPECTED URL"
+def test_meeting_ids():
+    for item in parsed_items:
+        assert item["id"] is not None


### PR DESCRIPTION
There are some production issues with the `PittHousingSpider`
- The location field needs something under the `name` key
- The meeting should have an `id` and `status` set. Using the default implementations from the base class, for now.
Also updated the test for this spider.