### PR TITLE
Fix pitt_urbandev date parsing logic

### DIFF
--- a/city_scrapers/spiders/pitt_urbandev.py
+++ b/city_scrapers/spiders/pitt_urbandev.py
@@ -71,6 +71,7 @@ class PittUrbandevSpider(CityScrapersSpider):
             """Parse start datetime as a naive datetime object."""
             raw = item.split("</h6>")[0]
             raw = re.sub("<h6>", "", raw)
+            raw = re.match(r".+ [0-9]+, [0-9]+", raw)[0]
             start_time = datetime.strptime(raw, "%B %d, %Y")
 
             if EXPECTED_START_HOUR in start_hour:


### PR DESCRIPTION
This resolves #169. 

The issue was a HTML element describing the date of the meeting. This element normally would look something like "October 21, 2020". In one case however we had something like "October 21, 2020 - Regular Meeting", which didn't match the expression given to the date parser, leading us to a ValueError. 

The fix was to add a regex matcher to find the date string within the raw string and pass that onto the date parser. 