### PR TITLE
Common string cleaning utilities and an example of their use

### DIFF
--- a/city_scrapers/common/cleaners.py
+++ b/city_scrapers/common/cleaners.py
@@ -1,0 +1,16 @@
+from unicodedata import normalize
+from w3lib.html import remove_tags
+
+UNICODE_FORM = "NFKD"
+
+"""
+Remove HTML tags, normalize to Unicode, and strip left and right whitespace. 
+"""
+
+
+def scrub_html(token: str) -> str:
+    assert type(token) is str
+    token = remove_tags(token)
+    token = normalize(UNICODE_FORM, token)
+    token = token.strip()
+    return token

--- a/city_scrapers/spiders/alle_improvements.py
+++ b/city_scrapers/spiders/alle_improvements.py
@@ -1,41 +1,10 @@
 from datetime import datetime  # convert utc time to datetime
-from html.parser import HTMLParser  # clean up HTML
 
 from city_scrapers_core.constants import BOARD
 from city_scrapers_core.items import Meeting
 from city_scrapers_core.spiders import CityScrapersSpider
 
-
-# Helper class for clean_date
-class MLStripper(HTMLParser):
-    # original author: eloff
-    # source: https://stackoverflow.com/questions/753052/strip-html-from-strings-in-python
-    def __init__(self):
-        self.reset()
-        self.strict = False
-        self.convert_charrefs = True
-        self.fed = []
-
-    def handle_data(self, d):
-        self.fed.append(d)
-
-    def get_data(self):
-        return "".join(self.fed)
-
-
-# Accepts an html string, returns a string without any html tags.
-# For example, clean_date("<h1>foo</h1>") will return just "foo".
-def clean_date(html):
-    # original author: eloff
-    # source: https://stackoverflow.com/questions/753052/strip-html-from-strings-in-python
-    s = MLStripper()
-    html = html.replace("\xa0", "")
-    html = html.replace("\r", "")
-    html = html.replace("\n", "")
-    s.feed(html)
-    cleaned = s.get_data()
-    cleaned = cleaned.replace(" ", "")  # Strip whitespace
-    return cleaned
+from city_scrapers.common.cleaners import scrub_html
 
 
 class AlleImprovementsSpider(CityScrapersSpider):
@@ -76,7 +45,7 @@ class AlleImprovementsSpider(CityScrapersSpider):
         root: str = '//*[@id="mainContainer"]/div[3]/section/div[1]/div[2]'
         path: str = root + "/div/div/div/div/div/table/tbody/tr/td[2]/p"
         dates_list: list = response.xpath(path)[0].get().split("<br>")
-        dates_list = list(map(clean_date, dates_list))
+        dates_list = list(map(scrub_html, dates_list))
         return dates_list
 
     def _parse_title(self) -> str:
@@ -95,7 +64,7 @@ class AlleImprovementsSpider(CityScrapersSpider):
         assert response.xpath(path).get() == expected
 
     def _parse_start(self, item) -> datetime:
-        date: datetime = datetime.strptime(item, "%B%d,%Y")
+        date: datetime = datetime.strptime(item, "%B %d, %Y")
         # Every meeting is assumed to take place at 9:30am
         # as asserted by _check_starting_hour_has_not_changed
         date_with_time_of_day: datetime = date.replace(hour=9, minute=30)


### PR DESCRIPTION
A majority of spiders in this project are attempting to parse HTML strings and
convert them into something more human-readable. The conversion step has been a
persistent pain point, it's time consuming, we're consistently getting this
wrong, and there exists many implementations of the same thing throughout our
codebase 😖 .

This new common code should allow us to refactor. Once a contributor drills down
to a single div, e.g. `<p>January 21, 2021\xa0</p>`, this cleaning function should
do the job 9 times out of 10.

Finally, we implement an example of the first common string cleaning function by
refactoring alle_improvements.