### PR TITLE
Add pitt_partner4work spider

### DIFF
--- a/city_scrapers/spiders/pitt_partner4work.py
+++ b/city_scrapers/spiders/pitt_partner4work.py
@@ -1,0 +1,108 @@
+import re
+from datetime import datetime
+
+from city_scrapers_core.constants import BOARD
+from city_scrapers_core.items import Meeting
+from city_scrapers_core.spiders import CityScrapersSpider
+
+# Start and end times not currently listed on Partner4Work website
+# However, a copy of their meeting minutes on line listed a recent meeting as being at 8:30 AM and ending at 9:30 AM
+START_TIME = "08:30 AM"
+END_TIME = "09:30 AM"
+DESCRIPTION = "Advanced registration is requested. Register at info@partner4work.org"
+
+monthDayYearPattern = "(January|February|March|April|May|June|July"
+monthDayYearPattern += "|August|September|October|November|December"
+monthDayYearPattern += ")\S* (\d+),\S* \d{4}"
+
+
+class PittPartner4WorkSpider(CityScrapersSpider):
+    name = "pitt_partner4work"
+    agency = "Partner4Work Workforce Development Board"
+    timezone = "America/New_York"
+    url = "https://www.partner4work.org/about/board-meetings"
+    start_urls = [url]
+
+    def parse(self, response):
+        self.logger.info("PARSING " + self.name + "...")
+        xpath = "//h3/text()[contains(.,'Board Meetings')]/following::ul/li"
+        events = response.xpath(xpath).getall()
+        for i in range(len(events)):
+            date = self.get_date(events[i])
+            if date != None:
+                meeting = Meeting(
+                    title=self._parse_title(),
+                    description=DESCRIPTION,
+                    classification=self._parse_classification(),
+                    start=self._parse_start(date),
+                    end=self._parse_end(date),
+                    all_day=False,
+                    # time_notes=self._parse_time_notes(response, i),
+                    location=self._parse_location(),
+                    links=self._parse_links(),
+                    source=self._parse_source(response),
+                    status=self._parse_status(),
+                )
+                # meeting["status"] = self._get_status(meeting)
+                meeting["id"] = self._get_id(meeting)
+                yield meeting
+
+    def _parse_status(self):
+        return "Tentative"
+
+    def _parse_title(self):
+        """Parse or generate meeting title."""
+        return self.agency + " Meeting"
+
+    def _parse_description(self, response):
+        """Parse or generate meeting description."""
+        return ""
+
+    def _parse_classification(self):
+        """Parse or generate classification from allowed options."""
+        return BOARD
+
+    def _parse_start(self, eventStr):
+        """Parse start datetime as a naive datetime object."""
+        eventStr = eventStr.strip().replace(",", "")
+        eventStr = eventStr + " " + START_TIME
+        formatString = "%B %d %Y %I:%M %p"
+        start = datetime.strptime(eventStr, formatString)
+        return start
+
+    def _parse_end(self, eventStr):
+        """Parse end datetime as a naive datetime object. Added by pipeline if None"""
+        eventStr = eventStr.strip().replace(",", "")
+        eventStr = eventStr + " " + END_TIME
+        formatString = "%B %d %Y %I:%M %p"
+        start = datetime.strptime(eventStr, formatString)
+        return start
+
+    def _parse_time_notes(self):
+        """Parse any additional notes on the timing of the meeting"""
+        return ""
+
+    def _parse_all_day(self):
+        """Parse or generate all-day status. Defaults to False."""
+        return False
+
+    def _parse_location(self):
+        """Seems like the meeting is always in the same place given the info in the Agenda PDFs."""
+        return None
+
+    def _parse_links(self):
+        """Parse or generate links."""
+        title = self.agency + " Meeting"
+        return [{"href": self.url, "title": title}]
+
+    def _parse_source(self, response):
+        """Parse or generate source."""
+        return response.url
+
+    def get_date(self, eventStr):
+        print("READING: " + eventStr)
+        result = re.search(monthDayYearPattern, eventStr)
+        if result != None:
+            return result.group(0)
+        else:
+            return None

--- a/tests/files/pitt_partner4work.html
+++ b/tests/files/pitt_partner4work.html
@@ -1,0 +1,284 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Board Meetings - Partner4Work</title>
+		<meta charset="UTF-8">
+		<meta name="language" content="en">
+		<meta name="description" content="Upcoming Board Meetings and Executive Committee Meetings ">
+		<meta name="keywords" content="Partners4Work, Partner for Work, Partners for Work">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+		<meta property="og:url" content="https://www.partner4work.org/about/board-meetings">
+		<meta property="og:type" content="article">
+		<meta property="og:title" content="Board Meetings">
+		<meta property="og:site_name" content="Partner4Work">
+		<meta property="og:description" content="Upcoming Board Meetings and Executive Committee Meetings ">
+									<meta property="og:image" content="https://www.partner4work.org/uploads/thumb/social-share-default.jpg">
+							
+		<link href="//fonts.googleapis.com/css?family=Oswald:400,700|Roboto:300,300i,700,700i" rel="stylesheet">
+		<link rel="stylesheet" type="text/css" href="/fonts/MyFontsWebfontsKit.css">
+		<link href="/css/normalize.css" rel="stylesheet" type="text/css" media="screen, projection">
+		<link href="/css/styles.css?v=20201124" rel="stylesheet" type="text/css" media="screen, projection">
+		<link href="/css/print.css" rel="stylesheet" type="text/css" media="print">
+		<link rel="stylesheet" href="/sss/sss.css" type="text/css" media="all">
+
+		<link rel="canonical" href="https://www.partner4work.org/about/board-meetings">
+
+		<script type="text/javascript" defer>
+	
+		  var _gaq = _gaq || [];
+		  _gaq.push(['_setAccount', 'UA-15260654-1']);
+		  _gaq.push(['_trackPageview']);
+	
+		  (function() {
+			 var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+			 ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+			 var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+		  })();
+	
+		</script>
+
+		
+		
+
+	</head>
+
+	<body class="section-about page-about_page_8 no-js">
+
+				
+		<section class="pagewrap">
+			
+			<header class="site-header-wrap">
+				<div  class="site-header">
+
+					<section class="mainnav-wrap sidebar-off">
+						<nav class="mainnav">
+							<div class="close-nav"><a href="#close">×</a></div>
+							<ul>
+																	<li>
+										<a href="/">
+											Home										</a>
+									</li>
+																	<li>
+										<a href="/about" class='current'>
+											About										</a>
+									</li>
+																	<li>
+										<a href="/services">
+											Services										</a>
+									</li>
+																	<li>
+										<a href="/impact">
+											Impact										</a>
+									</li>
+																	<li>
+										<a href="/programs">
+											Programs										</a>
+									</li>
+																	<li>
+										<a href="/research">
+											Research										</a>
+									</li>
+																	<li>
+										<a href="/news">
+											News										</a>
+									</li>
+																	<li>
+										<a href="/contact">
+											Contact										</a>
+									</li>
+															</ul>
+							<div class="site-search">
+								<form name="cse" id="searchbox" action="/search/" method="get">
+									<input type="hidden" name="cx" value="015361978393838658722:5zqjslqjj8o" />
+									<input type="hidden" name="ie" value="utf-8" />
+									<input type="hidden" name="hl" value="en" />
+									<input name="q" type="text" placeholder="What can we help you find?" />
+									<button name="sa">Search</button>
+								</form>
+							</div>
+						</nav>
+					</section>
+			
+					<div class="logo">
+													<a href="/">
+								<img src="/img/p4w-logo-stacked.svg" alt="Partner4Work" class="logo-stacked">
+								<img src="/img/p4w-logo-horizontal-tagline.svg" alt="Partner4Work" class="logo-horizontal">
+							</a>
+												
+						<div class="mobile-toggles">
+							<a href="#shownav" class="mainnav-toggle">Menu +</a>
+						</div>
+					</div>
+
+									</div>
+			</header>
+			
+			<section class="content-wrap">
+				
+	
+			
+
+	<section class="content content-header">
+		<h1>
+			Board Meetings		</h1>
+	</section>
+	
+		
+	<div class="content-columns-wrap">
+
+		<section class="content content-primary">
+			
+						
+			<!-- PUBLIC DOCUMENTS PAGE -->
+				
+	
+			<!-- STAFF PAGE -->
+						
+	
+			<!-- BOARD PAGE -->
+			
+
+			<!-- MEETINGS -->
+							
+														<h3 class="divider">Board Meetings</h3>
+					<p>As a publicly funded organization, Partner4Work Board of Directors' meetings are advertised in advance and are open to the public.</p>					<ul>
+													
+															<li>
+									December 11, 2020									<br>Advanced registration is requested. Register at info@partner4work.org.								</li>
+																										</ul>
+																			<h3 class="divider">Executive Committee Meetings</h3>
+					<p>As a publicly funded organization, Partner4Work Executive Committee meetings are advertised in advance and are open to the public. </p>					<ul>
+													
+																		</ul>
+																			<h3 class="divider">Standing Committees</h3>
+					<p><strong>Finance and Personnel</strong>  <em>Steve Massaro, Treasurer</em></p>
+<p><strong>Governance  </strong><em>Debra Caplan, Chair</em></p>
+<p><strong>Youth Advisory</strong>  <i>Debra Caplan, Chair</i></p>					<ul>
+													
+																		</ul>
+													
+				<div class="inset-box">
+					<h4>Briefing Books</h4>
+					<p>Partner4Work Board of Directors' Briefing Books are public documents. You may also request archived briefing books by sending an email to <a href="mailto:info@partner4work.org?Subject=Archived briefing book request">info@partner4work.org.</a></p>
+					<p>
+						<a href="/documents/board-brieifing-books/" class="btn">Download Current Briefing Book</a>
+					</p>
+				</div>
+	
+				
+	
+			<!-- CAREERS PAGE -->
+			
+	
+	
+			<!-- NEWS PAGE -->
+			
+		</section>
+		
+		<section class="content content-secondary">
+						<nav class="subnav">
+															<a href="/about/">
+							About						</a>
+																				<a href="/about/history/">
+							History						</a>
+																				<a href="/about/staff/">
+							Staff						</a>
+																				<a href="/about/board-directors/">
+							Board of Directors						</a>
+																				<a href="/about/board-meetings/" class='current'>
+							Board Meetings						</a>
+																				<a href="/about/careers/">
+							Career Opportunities						</a>
+																				<a href="/about/public-documents/">
+							Public Documents						</a>
+												</nav>
+					</section>
+		
+	</div><!-- /content-columns-wrap -->
+
+			</section><!-- /content-wrap -->
+
+		</section><!-- /pagewrap -->
+
+		<footer>
+			<div class="footer-wrap">
+				<section class="footer-logo">
+					<img src="/img/p4w-logo-white-stacked.svg" alt="Partner4Work" class="logo-stacked">
+					<img src="/img/p4w-logo-white-horizontal.svg" alt="Partner4Work" class="logo-horizontal">
+				</section>
+				<div class="footer-columns">
+					<section class="footer-address">
+						<p>
+							Centre City Tower, Suite 2600<br>
+650 Smithfield Street<br>
+							Pittsburgh, PA 15222<br>
+							<a href="mailto:info@partner4work.org">info@partner4work.org</a><br>
+							412-552-7090<br>
+							412-552-7091 fax
+						</p>
+					</section>	
+					<section class="social-icons">
+
+<!--
+						<div class="footer-title">Join Our Mailing List</div>
+						<form action="https://mizrahi.createsend.com/t/r/s/xhjjjj/" method="post" id="subForm">
+							<input type="text" name="cm-xhjjjj-xhjjjj" id="xhjjjj-xhjjjj" placeholder="Email address">
+							<button>Join</button>
+						</form>
+-->
+						<div class="footer-title">Connect With Us</div>
+						<p>
+															<a href="https://www.facebook.com/Partner4WorkPgh/" alt="Facebook"><img src="/img/facebook-icon.svg" alt="Facebook"></a>
+															<a href="http://twitter.com/PghWorkforce" alt="Twitter"><img src="/img/twitter-icon.svg" alt="Twitter"></a>
+															<a href="http://www.linkedin.com/company/partner4work-pittsburgh" alt="LinkedIn"><img src="/img/linkedin-icon.svg" alt="LinkedIn"></a>
+															<a href="https://www.youtube.com/user/3RiversWIB" alt="Youtube"><img src="/img/youtube-icon.svg" alt="Youtube"></a>
+															<a href="https://www.instagram.com/partner4work/" alt="Instagram"><img src="/img/instagram-icon.svg" alt="Instagram"></a>
+													</p>
+						<br>
+						<div class="createsend-button" style="height:27px;display:inline-block;" data-listid="r/A9/1E0/50A/5B69FCCB6A2551C1"></div><script type="text/javascript" defer>(function () { var e = document.createElement('script'); e.type = 'text/javascript'; e.async = true; e.src = ('https:' == document.location.protocol ? 'https' : 'http') + '://btn.createsend1.com/js/sb.min.js?v=3'; e.className = 'createsend-script'; var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(e, s); })();</script>
+					</section>	
+					<section class="footer-links">
+						<div class="footer-title">Quick Links</div>
+						<ul>
+<li><a href="/about/public-documents/">Public Documents</a></li>
+<li><a href="/programs/learn-earn/">Learn &amp; Earn</a></li>
+</ul>					</section>	
+				</div>
+				
+									<section class="footer-nav">
+													<a href="/">
+								Home							</a>
+													<a href="/about" class='current'>
+								About							</a>
+													<a href="/services">
+								Services							</a>
+													<a href="/impact">
+								Impact							</a>
+													<a href="/programs">
+								Programs							</a>
+													<a href="/research">
+								Research							</a>
+													<a href="/news">
+								News							</a>
+													<a href="/contact">
+								Contact							</a>
+											</section>				
+				
+				<section class="copyright">
+					<p>&copy; 2020 Partner4Work. All rights reserved.</p>
+					<p>Auxiliary aids and services are available on request to individuals with disabilities. Equal Opportunity Employer/Program.</p>
+<p>Formerly Three Rivers Workforce Investment Board, Partner4Work is the public workforce development board for Pittsburgh and Allegheny County, Pennsylvania.</p>				</section>
+			</div>
+		</footer>
+
+		<!-- Go to www.addthis.com/dashboard to customize your tools -->
+		<script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-583df2440c46d094" defer></script> 
+		
+		<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js" defer></script>
+		<script src="/js/downloads_tracking.js" defer></script>
+		<script src="/sss/sss.min.js" defer></script>
+		<script src="/js/jquery_functions.js" defer></script>
+
+	</body>
+</html>

--- a/tests/test_pitt_partner4work.py
+++ b/tests/test_pitt_partner4work.py
@@ -1,0 +1,83 @@
+from datetime import datetime
+from os.path import dirname, join
+
+import pytest
+
+from city_scrapers_core.utils import file_response
+from freezegun import freeze_time
+
+from city_scrapers.spiders.pitt_partner4work import PittPartner4WorkSpider
+
+test_response = file_response(
+    join(dirname(__file__), "files", "pitt_partner4work.html"),
+    url="https://www.partner4work.org/about/board-meetings",
+)
+spider = PittPartner4WorkSpider()
+
+freezer = freeze_time("2020-11-28")
+freezer.start()
+
+parsed_items = [item for item in spider.parse(test_response)]
+print(parsed_items)
+
+freezer.stop()
+
+
+def test_description():
+    assert (
+        "Advanced registration is requested. Register at info@partner4work.org"
+        in parsed_items[0]["description"]
+    )
+
+
+def test_title():
+    assert (
+        parsed_items[0]["title"] == "Partner4Work Workforce Development Board Meeting"
+    )
+
+
+def test_start():
+    assert parsed_items[0]["start"] == datetime(2020, 12, 11, 8, 30)
+
+
+def test_end():
+    assert parsed_items[0]["end"] == datetime(2020, 12, 11, 9, 30)
+
+
+def test_id():
+    assert (
+        parsed_items[0]["id"]
+        == "pitt_partner4work/202012110830/x/partner4work_workforce_development_board_meeting"
+    )
+
+
+def test_status():
+    assert parsed_items[0]["status"] == "Tentative"
+
+
+def test_location():
+    assert parsed_items[0]["location"] is None
+
+
+def test_source():
+    assert (
+        parsed_items[0]["source"] == "https://www.partner4work.org/about/board-meetings"
+    )
+
+
+def test_links():
+    assert parsed_items[0]["links"] == [
+        {
+            "href": "https://www.partner4work.org/about/board-meetings",
+            "title": "Partner4Work Workforce Development Board Meeting",
+        }
+    ]
+
+
+def test_classification():
+    assert parsed_items[0]["classification"] == "Board"
+
+
+@pytest.mark.parametrize("item", parsed_items)
+def test_all_day(item):
+    assert item["all_day"] is False


### PR DESCRIPTION
At the time of development, the website had only one meeting date to scrape. Consequently, it may need to be modified in the new year as multiple dates may be added.

Meeting times were not specified. A google search showed a previous meeting to be at 8:30 AM, and I emailed info@partner4work.org to confirm is this remained the case. If it is not, this spider will need to be revised.